### PR TITLE
Fix checkout redirect logic

### DIFF
--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,5 +1,5 @@
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -60,8 +60,13 @@ const Checkout = () => {
     });
   };
 
+  useEffect(() => {
+    if (items.length === 0) {
+      navigate('/cart');
+    }
+  }, [items, navigate]);
+
   if (items.length === 0) {
-    navigate('/cart');
     return null;
   }
 


### PR DESCRIPTION
## Summary
- redirect to `/cart` via `useEffect` in `Checkout`

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6841d01a498483238207db8257b5fbd6